### PR TITLE
Modify event query time function

### DIFF
--- a/be-events-calendar.php
+++ b/be-events-calendar.php
@@ -444,7 +444,7 @@ class BE_Events_Calendar {
 			$meta_query = array(
 				array(
 					'key' => 'be_event_end',
-					'value' => time(),
+					'value' => (int) current_time( 'timestamp' ),
 					'compare' => '>'
 				)
 			);


### PR DESCRIPTION
The `time()` function always returns UTC, whereas [`current_time()`](http://codex.wordpress.org/Function_Reference/current_time) is linked to the timezone settings.
