### PR TITLE
Fix event category rewrite should not be prepended with front

### DIFF
--- a/inc/events.php
+++ b/inc/events.php
@@ -329,7 +329,7 @@ class BE_Events_Calendar {
 			'show_ui'           => true,
 			'show_admin_column' => true,
 			'query_var'         => true,
-			'rewrite'           => array( 'slug' => 'event-category' ),
+			'rewrite'           => array( 'slug' => 'event-category', 'with_front' => false ),
 		) );
 	}
 


### PR DESCRIPTION
Events post type rewrite doesn’t use the front base.

Fixes #46.